### PR TITLE
Update link to Stack Exchange Zendesk listing

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -299,8 +299,8 @@
                                                      href="https://www.zendesk.com/apps/youtube-channel-integration/?source=author_website"
                                                      role="button">Install YouTube Integration via Zendesk Marketplace</a></div>
     <div style="text-align: center;padding:10px;"><a class="btn btn-lg btn-success"
-                                                     href="#"
-                                                     role="button">Install Stack Exchange Integration via Zendesk Marketplace (coming soon)</a></div>
+                                                     href="https://www.zendesk.com/apps/stack-for-zendesk/?source=author_website"
+                                                     role="button">Install Stack Exchange Integration via Zendesk Marketplace</a></div>
     <footer class="footer">
         <ul class="nav nav-pills">
             <li role="presentation"><a href="#" style="color:black;">&copy; 2017 Mikhail Vink</a></li>


### PR DESCRIPTION
The Stack Exchange listing is [now live](https://www.zendesk.com/apps/stack-for-zendesk/) on the Zendesk Marketplace. This adds a link from the button on the homepage to the listing.